### PR TITLE
Fix cmp register access on aarch64

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -834,9 +834,8 @@ static void printOperand(MCInst *MI, unsigned OpNum, SStream *O)
 #ifndef CAPSTONE_DIET
 				uint8_t access;
 
-				access = get_op_access(MI->csh, MCInst_getOpcode(MI), MI->ac_idx);
+				access = get_op_access(MI->csh, MCInst_getOpcode(MI), OpNum);
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].access = access;
-				MI->ac_idx++;
 #endif
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_REG;
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Reg;
@@ -867,9 +866,8 @@ static void printOperand(MCInst *MI, unsigned OpNum, SStream *O)
 #ifndef CAPSTONE_DIET
 				uint8_t access;
 
-				access = get_op_access(MI->csh, MCInst_getOpcode(MI), MI->ac_idx);
+				access = get_op_access(MI->csh, MCInst_getOpcode(MI), OpNum);
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].access = access;
-				MI->ac_idx++;
 #endif
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_IMM;
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].imm = imm;


### PR DESCRIPTION
This is a clone of https://github.com/aquynh/capstone/pull/1655

Original text:

This pr fixes https://github.com/aquynh/capstone/issues/1653

I noticed that the problem relies on the fact that cmp x0, x1 is in fact alias for subs xzr, x0, x1.
Now, when the method printAliasInstruction calls printOperand, it passes the correct operand number (skips the first register xzr, and asks for x0); however printOperand then uses MI->ac_idx to address which reg access information to return back - and this is wrong, as MI->ac_idx is initialized with 0 and it should use the proper OpNum argument that is passed to printOperand

IMHO MI->ac_idx is an artifact from arm32 that got carried over to the arm64 implementation, and as we don't need to deal with multiple register edge cases like pop {r1,r2,r3,r4...} I don't see the need for MI->ac_idx at all for arch64, but I am probably wrong (this is my first contribution to the project), let me know what do you think @aquynh .

This pr will fix also register access for other instructions that are actually aliases and hide a register like tst x0, x1 .