### PR TITLE
add support for aarch64 distributions

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -199,10 +199,11 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
     name = get_platform()
     if 'linux' in name:
         # linux_* platform tags are disallowed because the python ecosystem is fubar
-        # linux builds should be built in the centos 5 vm for maximum compatibility
+        # linux builds should be built in the centos 6 vm for maximum compatibility
         # see https://github.com/pypa/manylinux
-        # see also https://github.com/angr/angr-dev/blob/master/bdist.sh
-        sys.argv.insert(idx + 1, 'manylinux1_' + platform.machine())
+        # see also https://github.com/angr/angr-dev/blob/master/bdist.sh and
+        # https://www.python.org/dev/peps/pep-0599/
+        sys.argv.insert(idx + 1, 'manylinux2014_' + platform.machine())
     else:
         # https://www.python.org/dev/peps/pep-0425/
         sys.argv.insert(idx + 1, name.replace('.', '_').replace('-', '_'))


### PR DESCRIPTION
It looks like `manylinux1` does not seem to support aarch64 architectures (see [the manylinux README](https://github.com/pypa/manylinux#manylinux1)).

According to [PEP 599](https://www.python.org/dev/peps/pep-0599/#backwards-compatibility-with-manylinux2010-wheels) it seems like `manylinux2014` is what should be used instead.

This is a follow up of [an equivalent PR in `capstone`](https://github.com/aquynh/capstone/pull/1720).

cc: @pranith 